### PR TITLE
Opt-in and Firebase persistance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN npm install
 # Bundle app source
 COPY src/*.js /usr/src/app/
 
-CMD [ "node", "--use_strict", "index.js" ]
+CMD [ "node", "index.js" ]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,14 @@ default: build
 build:
 	docker build -t ustwo/wordy-slack-bot .
 run:
-	docker run --env SLACK_TOKEN=$(SLACK_TOKEN) --name wordy-slack-bot -d ustwo/wordy-slack-bot
+	docker run \
+		-e SLACK_TOKEN \
+		-e FIREBASE_PROJECT_ID \
+		-e FIREBASE_CLIENT_EMAIL \
+		-e FIREBASE_PRIVATE_KEY \
+		-e FIREBASE_DB_URL \
+		-e FIREBASE_DB_URL \
+		--name wordy-slack-bot -d ustwo/wordy-slack-bot
 rm:
 	docker rm -vf wordy-slack-bot
 	docker images -qf 'dangling=true' | awk '{print $1}' | xargs docker rmi

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Everyone part of Wordy's community, codebase and issue tracker is expected to fo
 
 ## Configuration
 
-Needs Slack bot token as an ENV var named `SLACK_TOKEN`. You can create a bot and get a token in https://YOURSLACK.slack.com/services/new/bot. For more information you can read [Slack Bots documentation](https://api.slack.com/bot-users). 
+ * `SLACK_TOKEN`: Slack Bot token. You can create a bot and get a token in https://YOURSLACK.slack.com/services/new/bot. For more information you can read [Slack Bots documentation](https://api.slack.com/bot-users).
+ * `FIREBASE_JSON_CONFIG`: path to the Firebase config JSON file.
+ * `FIREBASE_DB_URL`: Firebase's database URL. 
 
 ## Development
 
@@ -41,7 +43,7 @@ Please make sure you have gone first through the [Configuration requirements](#c
 Wordy is a Node app so if you don't want to go down the Docker route for whatever reason, go through the [Development requirements](#development) and then run:
 
 ```sh
-node --use_strict src/index.js
+node src/index.js
 ```
 
 ## Test

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Everyone part of Wordy's community, codebase and issue tracker is expected to fo
 ## Configuration
 
  * `SLACK_TOKEN`: Slack Bot token. You can create a bot and get a token in https://YOURSLACK.slack.com/services/new/bot. For more information you can read [Slack Bots documentation](https://api.slack.com/bot-users).
- * `FIREBASE_JSON_CONFIG`: path to the Firebase config JSON file.
- * `FIREBASE_DB_URL`: Firebase's database URL. 
+ * `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`, `FIREBASE_DB_URL` if you want to provide persitance through Firebase.
+ * `WORDY_WEBSERVER_PORT` and `WORDY_WEBSERVER_HOST` for the webserver that handles the Slack commands.
 
 ## Development
 

--- a/bot.yml
+++ b/bot.yml
@@ -1,0 +1,16 @@
+config:
+  - name: FIREBASE_PROJECT_ID
+    type: secret
+    global: false
+  - name: FIREBASE_CLIENT_EMAIL
+    type: secret
+    global: false
+  - name: FIREBASE_PRIVATE_KEY
+    type: secret
+    global: false
+  - name: FIREBASE_DB_URL
+    type: secret
+    global: false
+  - name: WORDY_WEBSERVER_HOST
+    default: '0.0.0.0'
+    global: false

--- a/package.json
+++ b/package.json
@@ -10,8 +10,12 @@
     "lint": "./node_modules/eslint/bin/eslint.js src/ --no-ignore .eslintrc.js"
   },
   "dependencies": {
-    "slackbots": "0.5.3",
-    "firebase": ""
+    "body-parser": "^1.15.2",
+    "express": "^4.14.0",
+    "firebase": "^3.6.0",
+    "firebase-admin": "^4.0.1",
+    "helmet": "^3.1.0",
+    "slackbots": "0.5.3"
   },
   "devDependencies": {
     "eslint": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "author": "ustwo Fampany",
   "license": "MIT",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha test/ --use_strict",
+    "test": "./node_modules/mocha/bin/mocha test/",
     "lint": "./node_modules/eslint/bin/eslint.js src/ --no-ignore .eslintrc.js"
   },
   "dependencies": {
-    "slackbots": "0.5.3"
+    "slackbots": "0.5.3",
+    "firebase": ""
   },
   "devDependencies": {
     "eslint": "^3.8.1",

--- a/src/firebase_datastore.js
+++ b/src/firebase_datastore.js
@@ -10,12 +10,17 @@ class FirebaseDataStore {
 
   isUserInterested(userId, successCallback, errorCallback) {
     this.db.ref(`users/${userId}`).once('value', function(data) {
-      const userData = data.val();
-      const interested = (userData != null)? userData.interested : false;
-      successCallback(interested);
+
+      if (successCallback){
+        const userData = data.val();
+        const interested = (userData != null)? userData.interested : false;
+        successCallback(interested);
+      }
     }, function(errorObject) {
       console.log("Firebase DataStore error: " + errorObject);
-      errorCallback(errorObject.code);
+      if (errorCallback) {
+        errorCallback(errorObject.code);
+      }
     });
   }
 

--- a/src/firebase_datastore.js
+++ b/src/firebase_datastore.js
@@ -1,5 +1,8 @@
 "use strict"
 
+// Reference:
+// https://firebase.google.com/docs/database/admin/start
+
 class FirebaseDataStore {
   constructor(db){
     this.db = db;
@@ -13,6 +16,20 @@ class FirebaseDataStore {
     }, function(errorObject) {
       console.log("Firebase DataStore error: " + errorObject);
       errorCallback(errorObject.code);
+    });
+  }
+
+  registerUser(userId, isInterested, successCallback, errorCallback) {
+    this.db.ref(`users/${userId}`).update({interested: isInterested}, function(error){
+      if (error) {
+        if (errorCallback){
+          errorCallback(error);
+        }
+      } else {
+        if (successCallback){
+          successCallback();
+        }
+      }
     });
   }
 }

--- a/src/firebase_datastore.js
+++ b/src/firebase_datastore.js
@@ -1,0 +1,22 @@
+"use strict"
+
+class FirebaseDataStore {
+  constructor(db){
+    this.db = db;
+  }
+
+  isUserInterested(userId, successCallback, errorCallback) {
+    this.db.ref(`users/${userId}`).once('value', function(data) {
+      const userData = data.val();
+      const interested = (userData != null)? userData.interested : false;
+      successCallback(interested);
+    }, function(errorObject) {
+      console.log("Firebase DataStore error: " + errorObject);
+      errorCallback(errorObject.code);
+    });
+  }
+}
+
+module.exports = {
+  FirebaseDataStore,
+};

--- a/src/firebase_datastore.js
+++ b/src/firebase_datastore.js
@@ -9,14 +9,13 @@ class FirebaseDataStore {
   }
 
   isUserInterested(userId, successCallback, errorCallback) {
-    this.db.ref(`users/${userId}`).once('value', function(data) {
-
+    this.db.ref(`users/${userId}`).once('value', (data) => {
       if (successCallback){
         const userData = data.val();
         const interested = (userData != null)? userData.interested : false;
         successCallback(interested);
       }
-    }, function(errorObject) {
+    }, (errorObject) => {
       console.log("Firebase DataStore error: " + errorObject);
       if (errorCallback) {
         errorCallback(errorObject.code);

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,19 @@
 "use strict"
 
 const SlackBot = require('slackbots');
-const firebase = require ('firebase');
+const firebase = require('firebase-admin');
 const bots = require('./wordy_bot.js');
+const servers = require('./wordy_webserver.js');
 const models = require('./models.js');
 const reactions = require('./reactions.js');
 const dataStore = require('./firebase_datastore.js');
 
 firebase.initializeApp({
-  serviceAccount: process.env.FIREBASE_JSON_CONFIG,
+  credential: firebase.credential.cert({
+    projectId: process.env.FIREBASE_PROJECT_ID,
+    clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+    privateKey: process.env.FIREBASE_PRIVATE_KEY.replace(/(\\n)/g, '\n'),
+  }),
   databaseURL: process.env.FIREBASE_DB_URL
 });
 
@@ -30,3 +35,8 @@ rules.add(new models.Rule(expression, reaction));
 // While I understand the rule, I really prefer to have a class
 // and and instance here for consistency with the rest of the code.
 new bots.WordyBot(ds, slackBot, rules);
+
+const webServerPort = process.env.PORT || process.env.WORDY_WEBSERVER_PORT || 33333;
+const webServerHost = process.env.WORDY_WEBSERVER_HOST || '0.0.0.0';
+
+new servers.WordyWebServer(ds, webServerPort, webServerHost);

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,18 @@
+"use strict"
+
 const SlackBot = require('slackbots');
+const firebase = require ('firebase');
 const bots = require('./wordy_bot.js');
 const models = require('./models.js');
 const reactions = require('./reactions.js');
+const dataStore = require('./firebase_datastore.js');
+
+firebase.initializeApp({
+  serviceAccount: process.env.FIREBASE_JSON_CONFIG,
+  databaseURL: process.env.FIREBASE_DB_URL
+});
+
+const ds = new dataStore.FirebaseDataStore(firebase.database());
 
 // TODO: error out if no token found
 const slackBot = new SlackBot({
@@ -18,4 +29,4 @@ rules.add(new models.Rule(expression, reaction));
 /* eslint-disable no-new */
 // While I understand the rule, I really prefer to have a class
 // and and instance here for consistency with the rest of the code.
-new bots.WordyBot(slackBot, rules);
+new bots.WordyBot(ds, slackBot, rules);

--- a/src/language_checker.js
+++ b/src/language_checker.js
@@ -1,3 +1,5 @@
+"use strict"
+
 const reactions = require('./reactions.js');
 
 class LanguageChecker {

--- a/src/message_handler.js
+++ b/src/message_handler.js
@@ -1,3 +1,5 @@
+"use strict"
+
 const models = require('./models.js');
 
 class MessageHandler {

--- a/src/models.js
+++ b/src/models.js
@@ -1,3 +1,5 @@
+"use strict"
+
 class UserMessage {
   constructor(userId, text) {
     this.userId = userId;

--- a/src/reactions.js
+++ b/src/reactions.js
@@ -1,3 +1,5 @@
+"use strict"
+
 class ReactionNone {
 }
 

--- a/src/wordy_bot.js
+++ b/src/wordy_bot.js
@@ -35,7 +35,7 @@ class WordyBot {
         if (reaction instanceof reactions.ReactionDirectMessage) {
           console.log('Offending message');
 
-          dataStore.isUserInterested(userMessage.userId, function(isInterested) {
+          dataStore.isUserInterested(userMessage.userId, (isInterested) => {
 
             if (isInterested) {
               console.log("User is interested");
@@ -61,6 +61,8 @@ class WordyBot {
             } else {
               console.log(userMessage.userId + " IS ***NOT**** INTERESTED");
             }
+          }, (error) => {
+            console.log(`DATA STORE ERROR: ${error}`);
           }); // is user interested callback
         } // reaction is direct message
       }

--- a/src/wordy_bot.js
+++ b/src/wordy_bot.js
@@ -1,10 +1,12 @@
+"use strict"
+
 const handler = require('./message_handler.js');
 const checker = require('./language_checker.js');
 const models = require('./models.js');
 const reactions = require('./reactions.js');
 
 class WordyBot {
-  constructor(slackBot, rules) {
+  constructor(dataStore, slackBot, rules) {
     // TODO: extract the anonymous callbacks from each slackBot.on call
     // so they can be tested outside the event cycle
     slackBot.on('start', () => {
@@ -27,29 +29,40 @@ class WordyBot {
       const userMessage = handler.MessageHandler.getUserMessage(slackData);
 
       if (userMessage instanceof models.UserMessage) {
+
         const reaction = new checker.LanguageChecker(rules).check(userMessage);
 
         if (reaction instanceof reactions.ReactionDirectMessage) {
           console.log('Offending message');
 
-          // TODO: this is ugly because apparently the only way to send a DM
-          // is via the user name, which doesn't come from the slack_data object received.
-          // Can't really belive that, so let's investigate.
-          slackBot.getUsers().then((usersData) => {
-            const users = usersData.members;
-            let x = 0;
-            let user = null;
+          dataStore.isUserInterested(userMessage.userId, function(isInterested) {
 
-            for (; x < users.length; x += 1) {
-              user = users[x];
+            if (isInterested) {
+              console.log("User is interested");
 
-              if (user.id === userMessage.userId) {
-                reaction.execute(user.name, slackBot);
-                break;
-              }
+              // TODO: this is ugly because apparently the only way to send a DM
+              // is via the user name, which doesn't come from the slack_data object received.
+              // Can't really belive that, so let's investigate.
+              slackBot.getUsers().then((usersData) => {
+                const users = usersData.members;
+                let x = 0;
+                let user = null;
+
+                for (; x < users.length; x += 1) {
+                  user = users[x];
+
+                  if (user.id === userMessage.userId) {
+                    reaction.execute(user.name, slackBot);
+                    break;
+                  }
+                }
+              });
+
+            } else {
+              console.log(userMessage.userId + " IS ***NOT**** INTERESTED");
             }
-          });
-        }
+          }); // is user interested callback
+        } // reaction is direct message
       }
     });
   }

--- a/src/wordy_webserver.js
+++ b/src/wordy_webserver.js
@@ -1,0 +1,65 @@
+"use strict"
+
+const express = require('express');
+const bodyParser = require('body-parser');
+const helmet = require('helmet');
+// http://expressjs.com/en/advanced/best-practice-security.html
+
+class WordyWebServer {
+  constructor(storage, port, host) {
+    this.storage = storage;
+    this.webapp = express();
+    this.webapp.use(helmet());
+    this.webapp.use(bodyParser.urlencoded({ extended: true }));
+
+    this.webapp.get('/', (req, res) => {
+      res.send('WordyBot');
+    });
+
+    this.webapp.post('/slack/command', (req, res) => {
+
+      const command = req.body.command;
+      const userId = req.body.user_id;
+
+      console.log('Command received via hook');
+      console.log(`Command: ${command}`);
+      console.log(`User ID: ${userId}`);
+
+      switch (command) {
+        case '/wordy-in':
+          registerUser(userId, () => {
+            res.send('Thank you for registering.');
+          }, (error) => {
+            res.send(`Ooops, something went wrong: ${error}`);
+          });
+          break;
+        case '/wordy-out':
+          unregisterUser(userId, () => {
+            res.send('Sad to see you go.');
+          }, (error) => {
+            res.send(`Ooops, something went wrong: ${error}`);
+          });
+          break;
+        default:
+          console.error('Unknown command, ignoring');
+          break;
+      }
+    });
+
+    this.webapp.listen(port, host, () => {
+      console.log(`Wordy Web App up and running at http://${host}:${port}`);
+    });
+  }
+
+  registerUser(userId, successCallback, errorCallback) {
+    this.storage.registerUser(userId, true, successCallback, errorCallback);
+  }
+
+  unregisterUser(userId, successCallback, errorCallback) {
+    this.storage.registerUser(userId, false, successCallback, errorCallback);
+  }
+}
+
+module.exports = {
+  WordyWebServer,
+};

--- a/test/firebase_datastore_test.js
+++ b/test/firebase_datastore_test.js
@@ -13,7 +13,8 @@ describe('Firebase Data Store', function(){
     // Bit too much set up :|
     mock_db = {ref: function(){}};
     mock_once = sandbox.spy();
-    mock_ref = sandbox.stub(mock_db, 'ref').returns({once: mock_once});
+    mock_update = sandbox.spy();
+    mock_ref = sandbox.stub(mock_db, 'ref').returns({once: mock_once, update: mock_update});
     mock_success_callback = sandbox.spy();
     mock_error_callback = sandbox.spy();
 
@@ -69,6 +70,37 @@ describe('Firebase Data Store', function(){
     mock_once.args[0][2](errorObject);
 
     assert(mock_error_callback.calledWith(errorObject.code));
+  });
+
+  it('Should appropriately opt in a user', function(){
+    ds.registerUser('USER_ID', true);
+
+    assert(mock_ref.calledWith('users/USER_ID'));
+    assert(mock_update.calledWith({interested: true}));
+  });
+
+  it('Should appropriately opt out a user', function(){
+    ds.registerUser('USER_ID', false);
+
+    assert(mock_ref.calledWith('users/USER_ID'));
+    assert(mock_update.calledWith({interested: false}));
+  });
+
+  it('Should call the success callback after successful update', function(){
+    ds.registerUser('USER_ID', false, mock_success_callback);
+
+    mock_update.args[0][1]();
+
+    assert(mock_success_callback.calledWithExactly());
+  });
+
+  it('Should call the error callback after unsuccessful update', function(){
+    ds.registerUser('USER_ID', false, mock_success_callback, mock_error_callback);
+
+    const db_error = 'XXXXX';
+    mock_update.args[0][1](db_error);
+
+    assert(mock_error_callback.calledWithExactly(db_error));
   });
 });
 

--- a/test/firebase_datastore_test.js
+++ b/test/firebase_datastore_test.js
@@ -1,0 +1,77 @@
+const assert = require('assert');
+const should = require('should');
+const sinon = require('sinon');
+const dataStore = require('../src/firebase_datastore.js');
+
+describe('Firebase Data Store', function(){
+
+  var sandbox, mock_db, mock_once, mock_ref, mock_success_callback, ds;
+
+  beforeEach(function(){
+    sandbox = sinon.sandbox.create();
+
+    // Bit too much set up :|
+    mock_db = {ref: function(){}};
+    mock_once = sandbox.spy();
+    mock_ref = sandbox.stub(mock_db, 'ref').returns({once: mock_once});
+    mock_success_callback = sandbox.spy();
+    mock_error_callback = sandbox.spy();
+
+    ds = new dataStore.FirebaseDataStore(mock_db);
+  });
+
+  afterEach(function(){
+    sandbox.restore();
+  });
+
+  it('Should call Firebase JS SDK appropiately', function(){
+    ds.isUserInterested('USER_ID');
+
+    assert(mock_ref.calledWith('users/USER_ID'));
+    assert(mock_once.calledWith('value'));
+  });
+
+  it('Should return false if the user has not registered', function(){
+    ds.isUserInterested('USER_ID', mock_success_callback);
+
+    // Firebase returns null for data.val() if
+    // no record can be found
+    mock_once.args[0][1]({val: function(){ return null;}});
+
+    assert(mock_success_callback.calledWith(false));
+  });
+
+  it('Should return false if the user has opted out', function() {
+    ds.isUserInterested('USER_ID', mock_success_callback);
+
+    mock_once.args[0][1](getMockDbData(false));
+
+    assert(mock_success_callback.calledWith(false));
+  });
+
+  it('Should return true if the user has opted in', function(){
+    ds.isUserInterested('USER_ID', mock_success_callback);
+
+    // This is executing the success callback
+    // passing our mocked db data
+    mock_once.args[0][1](getMockDbData(true));
+
+    assert(mock_success_callback.calledWith(true));
+  });
+
+  it('Should call error callback appropiately when there is a Firebase error', function(){
+    ds.isUserInterested('USER_ID', mock_success_callback, mock_error_callback);
+
+    const errorObject = {code: 'XXXXX'};
+
+    // This is executing the error callback
+    // passing the mock error object
+    mock_once.args[0][2](errorObject);
+
+    assert(mock_error_callback.calledWith(errorObject.code));
+  });
+});
+
+function getMockDbData(isUserInterested){
+  return {val: function(){ return {interested: isUserInterested};}};
+}

--- a/test/wordy_bot_test.js
+++ b/test/wordy_bot_test.js
@@ -12,7 +12,7 @@ describe('WordyBot', function(){
 
     sinon.spy(slackBot, 'on');
 
-    const bot = new bots.WordyBot(slackBot);
+    const bot = new bots.WordyBot(null, slackBot, null);
 
     assert(slackBot.on.calledWith('message'));
 

--- a/test/wordy_websever_test.js
+++ b/test/wordy_websever_test.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+const should = require('should');
+const sinon = require('sinon');
+const bots = require('../src/wordy_webserver.js');
+
+describe('Wordy WebServer', function(){
+  it('Should display a nice homepage');
+});


### PR DESCRIPTION
Moving to an opt-in model, there won't be a reaction from the bot unless the user has explicitly asked to be informed of offending words.

For now persistence is only provided using Firebase as the data store.

Right now I'm looking for feedback for `src/firebase_datastore.js` and `test/firebase_datastore_test.js` only.

You can see [Firebase server implementation reference](https://firebase.google.com/docs/database/admin/start).

Tests can be run via `npm test`.

Sadly, Firebase JS SDK does not run in strict mode in Node so we need to start using "use strict" at the top of each source file. Linting is broken for now because of this (will be fixed before merge).

@arnau I've added you as an owner of the sample Firebase project, so you can see the (WIP) data structure [here](https://console.firebase.google.com/project/testwordy/database/data).