### PR TITLE
Set ESLint to allow global strict directives.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,18 @@
+'use strict';
+
 module.exports = {
+  root: true,
   extends: 'airbnb-base',
   rules: {
     // Turning off errors about using console, since this is a Node app,
     // as recommended here: http://eslint.org/docs/rules/no-console#when-not-to-use-it
     'no-console': 'off',
+    strict: ['error', 'global'],
+  },
+  parserOptions: {
+    sourceType: 'script',
+  },
+  ecmaFeatures: {
+    impliedStrict: false,
   },
 };


### PR DESCRIPTION
The airbnb rules expect es6 modules but with node we don't use them. This
change sets the `sourceType` to "script", and enforces to have a directive
"strict" in any global scope (i.e. file).

More info: http://eslint.org/docs/rules/strict

## Review

Run `npm run lint` and expect no errors.