### PR TITLE
Moved terms and reactions rules to JSON file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,6 @@ RUN npm install
 
 # Bundle app source
 COPY src/*.js /usr/src/app/
+COPY config.json /usr/src/app/
 
 CMD [ "node", "index.js" ]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Everyone part of Wordy's community, codebase and issue tracker is expected to fo
  * `SLACK_COMMAND_TOKEN` and `SLACK_TEAM_ID` to validate that commands are coming from your team.
  * `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`, `FIREBASE_DB_URL` if you want to provide persitance through Firebase.
  * `WORDY_WEBSERVER_PORT` and `WORDY_WEBSERVER_HOST` for the webserver that handles the Slack commands.
+ * `config.json`: Contains the terms and associated reactions.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Wordy
 
-Wordy is a Slack bot that helps you stay clear of common, but unnecessary gendered words and ableisms.
+Wordy is a Slack bot that helps you stay clear of common, but unnecessary gendered words and ableisms. Some examples are "guys", "mad", "crazy", etc.
 
-Some examples are "guys", "mad", "crazy", etc.
-
-For now you can have a read at [WeAllJS take on it](http://wealljs.org/rfc-slackbot-language-shorthands):
+We take inspiration from [We All JS language shorthands](http://wealljs.org/rfc-slackbot-language-shorthands):
 
 > The enforcement process [...] is focused around being kind, and on accepting corrections and moving on peacefully.
+
+You can see the full list of terms and reactions, which we have also borrowed from We All JS, in our [config.json](./config.json).
 
 ## Status
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,21 @@
+{
+	"rules": [{
+		"term": "crazy",
+		"reaction": "Words like \"Insane\" and \"Crazy\" are poor choices for a general-purpose intensifier. Think about how it feels to read that for someone facing mental health issues. How about \"Shocking\", \"Incredible\", \"Ridiculous\" or something thoughtful about the specific thing you're discussing?"
+	}, {
+		"term": "mad",
+		"reaction": "Words like \"Mad\" are poor choices for a synonym for anger. Think about how it feels to read that for someone facing mental health issues. How about \"Angry\", \"Furious\", \"Upset\", or something thoughtful about the specific thing you’re discussing? For historical context, \"mad\" is considered pejorative in the U.K. but often used as a synonym for angry in the U.S. (and seen as less charged). But given that we are a global community, it’s important to take note of the different valences a word can have and practice using terms that are widely inclusive."
+	}, {
+		"term": "guys",
+		"reaction": "The word \"Guys\", and other related gendered terms for a group of people are poor choices to refer to a diverse group. Try using \"People\", \"Friends\", \"Folks\", \"Y’all\", or just leave the word out entirely."
+	}, {
+		"term": "stupid",
+		"reaction": "Words like \"Stupid\", \"Idiotic\", \"Dumb\", and other terms relating to personal intelligence are a poor choice to describe the context in which something happened, due to their use around people with learning difficulties. How about \"Ill-advised\" or \"Unwise\", or a more detailed description of what happened?"
+	}, {
+		"term": "lame",
+		"reaction": "Words like \"lame\" are a poor choice as a synonym for \"boring\" or \"uninteresting\". This is an ableist term that implies that experiencing difficulty with mobility/walking is somehow inherently bad. Try using, \"boring\", \"uneventful\", \"tedious\" or avoid the word altogether."
+	}, {
+		"term": "spaz",
+		"reaction": "The word \"spaz\" or the phrase \"spazzing out\" is used in English (UK, and the US, to a lesser extent) as an epithet, meaning, \"to lose control of your actions, thoughts, or speech\". It is derived from the word \"spastic\", a now-obsolete medical term to refer to people with conditions affecting cognitive and motor function. Try instead to describe your situation in detail or avoid the use of this term altogether."
+	}]
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,20 +8,35 @@ const servers = require('./wordy_webserver.js');
 const rules = require('./rules.js');
 const dataStore = require('./firebase_datastore.js');
 
+// Pull relevant ENV vars into constants
+const { FIREBASE_PROJECT_ID,
+        FIREBASE_CLIENT_EMAIL,
+        FIREBASE_PRIVATE_KEY,
+        FIREBASE_DB_URL,
+        SLACK_TOKEN,
+        SLACK_COMMAND_TOKEN,
+        SLACK_TEAM_ID,
+        WORDY_WEBSERVER_PORT,
+        WORDY_WEBSERVER_HOST,
+        PORT,
+        } = process.env;
+
+console.log(FIREBASE_PROJECT_ID);
+
 firebase.initializeApp({
   credential: firebase.credential.cert({
-    projectId: process.env.FIREBASE_PROJECT_ID,
-    clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-    privateKey: process.env.FIREBASE_PRIVATE_KEY.replace(/(\\n)/g, '\n'),
+    projectId: FIREBASE_PROJECT_ID,
+    clientEmail: FIREBASE_CLIENT_EMAIL,
+    privateKey: FIREBASE_PRIVATE_KEY.replace(/(\\n)/g, '\n'),
   }),
-  databaseURL: process.env.FIREBASE_DB_URL,
+  databaseURL: FIREBASE_DB_URL,
 });
 
 const ds = new dataStore.FirebaseDataStore(firebase.database());
 
 // TODO: error out if no token found
 const slackBot = new SlackBot({
-  token: process.env.SLACK_TOKEN,
+  token: SLACK_TOKEN,
 });
 
 const rulesJson = JSON.parse(fs.readFileSync('./config.json', { encoding: 'utf8' }));
@@ -32,9 +47,9 @@ const wordyRules = rules.rulesFromJson(rulesJson);
 // and and instance here for consistency with the rest of the code.
 new bots.WordyBot(ds, slackBot, wordyRules);
 
-const webServerPort = process.env.PORT || process.env.WORDY_WEBSERVER_PORT || 33333;
-const webServerHost = process.env.WORDY_WEBSERVER_HOST || '0.0.0.0';
-const slackCommandToken = process.env.SLACK_COMMAND_TOKEN;
-const slackTeamId = process.env.SLACK_TEAM_ID;
+const webServerPort = PORT || WORDY_WEBSERVER_PORT || 33333;
+const webServerHost = WORDY_WEBSERVER_HOST || '0.0.0.0';
+const slackCommandToken = SLACK_COMMAND_TOKEN;
+const slackTeamId = SLACK_TEAM_ID;
 
 new servers.WordyWebServer(ds, webServerPort, webServerHost, slackCommandToken, slackTeamId);

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,10 @@
 
 const SlackBot = require('slackbots');
 const firebase = require('firebase-admin');
+const fs = require('fs');
 const bots = require('./wordy_bot.js');
 const servers = require('./wordy_webserver.js');
-const models = require('./models.js');
-const reactions = require('./reactions.js');
+const rules = require('./rules.js');
 const dataStore = require('./firebase_datastore.js');
 
 firebase.initializeApp({
@@ -24,17 +24,13 @@ const slackBot = new SlackBot({
   token: process.env.SLACK_TOKEN,
 });
 
-const rules = new models.Rules();
-
-// TODO: this should obs come from some JSON config or similar
-const expression = new RegExp(/guys/);
-const reaction = new reactions.ReactionDirectMessage('Guys is not cool');
-rules.add(new models.Rule(expression, reaction));
+const rulesJson = JSON.parse(fs.readFileSync('./config.json', { encoding: 'utf8' }));
+const wordyRules = rules.rulesFromJson(rulesJson);
 
 /* eslint-disable no-new */
 // While I understand the rule, I really prefer to have a class
 // and and instance here for consistency with the rest of the code.
-new bots.WordyBot(ds, slackBot, rules);
+new bots.WordyBot(ds, slackBot, wordyRules);
 
 const webServerPort = process.env.PORT || process.env.WORDY_WEBSERVER_PORT || 33333;
 const webServerHost = process.env.WORDY_WEBSERVER_HOST || '0.0.0.0';

--- a/src/message_handler.js
+++ b/src/message_handler.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const models = require('./models.js');
+const messages = require('./messages.js');
 
 class MessageHandler {
   static getUserMessage(slackData) {
-    let userMessage = new models.NoMessage();
+    let userMessage = new messages.NoMessage();
 
     if (slackData.type === 'message' && slackData.user !== undefined) {
-      userMessage = new models.UserMessage(slackData.user, slackData.text);
+      userMessage = new messages.UserMessage(slackData.user, slackData.text);
     }
 
     return userMessage;

--- a/src/messages.js
+++ b/src/messages.js
@@ -15,26 +15,7 @@ class UserMessage {
 class NoMessage {
 }
 
-class Rule {
-  constructor(expression, reaction) {
-    this.expression = expression;
-    this.reaction = reaction;
-  }
-}
-
-class Rules {
-  constructor() {
-    this.rules = [];
-  }
-
-  add(rule) {
-    this.rules.push(rule);
-  }
-}
-
 module.exports = {
   UserMessage,
   NoMessage,
-  Rules,
-  Rule,
 };

--- a/src/rules.js
+++ b/src/rules.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const reactions = require('./reactions.js');
+
+class Rule {
+  constructor(expression, reaction) {
+    this.expression = expression;
+    this.reaction = reaction;
+  }
+}
+
+class Rules {
+  constructor() {
+    this.rules = [];
+  }
+
+  add(rule) {
+    this.rules.push(rule);
+  }
+
+  length() {
+    return this.rules.length;
+  }
+}
+
+function rulesFromJson(json) {
+  if (!json || !json.rules || json.rules.length <= 0) {
+    throw new Error('No rules found');
+  }
+
+  const rules = new Rules();
+
+  json.rules.map((entry) => {
+    if (entry.term && entry.reaction) {
+      rules.add(
+        new Rule(
+          new RegExp(entry.term),
+          new reactions.ReactionDirectMessage(entry.reaction)
+        )
+      );
+    }
+
+    return entry;
+  });
+
+  if (rules.length() <= 0) {
+    throw new Error('No rules found');
+  }
+
+  return rules;
+}
+
+module.exports = {
+  rulesFromJson,
+  Rules,
+  Rule,
+};

--- a/src/rules.js
+++ b/src/rules.js
@@ -34,7 +34,7 @@ function rulesFromJson(json) {
     if (entry.term && entry.reaction) {
       rules.add(
         new Rule(
-          new RegExp(entry.term),
+          new RegExp(entry.term, 'i'),
           new reactions.ReactionDirectMessage(entry.reaction)
         )
       );

--- a/src/wordy_bot.js
+++ b/src/wordy_bot.js
@@ -2,7 +2,7 @@
 
 const handler = require('./message_handler.js');
 const checker = require('./language_checker.js');
-const models = require('./models.js');
+const messages = require('./messages.js');
 const reactions = require('./reactions.js');
 
 class WordyBot {
@@ -28,7 +28,7 @@ class WordyBot {
     slackBot.on('message', (slackData) => {
       const userMessage = handler.MessageHandler.getUserMessage(slackData);
 
-      if (userMessage instanceof models.UserMessage) {
+      if (userMessage instanceof messages.UserMessage) {
         const reaction = new checker.LanguageChecker(rules).check(userMessage);
 
         if (reaction instanceof reactions.ReactionDirectMessage) {

--- a/test/language_checker_test.js
+++ b/test/language_checker_test.js
@@ -1,14 +1,15 @@
 const assert = require('assert');
 const should = require('should');
-const models = require('../src/models.js');
+const messages = require('../src/messages.js');
 const reactions = require('../src/reactions.js');
 const checker = require('../src/language_checker.js');
+const rules = require('../src/rules.js');
 
 describe("Message / Reaction", function(){
 
   it('Should return no action if no offending pattern found', function(){
 
-    const user_message = new models.UserMessage('alsdkjasl', 'hello');
+    const user_message = new messages.UserMessage('alsdkjasl', 'hello');
     const reaction = new checker.LanguageChecker(defaultRules()).check(user_message);
 
     reaction.should.be.instanceOf(reactions.ReactionNone);
@@ -16,7 +17,7 @@ describe("Message / Reaction", function(){
 
   it('Should return DM action if offending pattern found', function(){
 
-    const user_message = new models.UserMessage('alsdkjasl', 'hello guys');
+    const user_message = new messages.UserMessage('alsdkjasl', 'hello guys');
     const reaction = new checker.LanguageChecker(defaultRules()).check(user_message);
 
     reaction.should.be.instanceOf(reactions.ReactionDirectMessage);
@@ -25,11 +26,11 @@ describe("Message / Reaction", function(){
 
 function defaultRules(){
 
-  const rules = new models.Rules();
+  const defRules = new rules.Rules();
   const expression = new RegExp(/guys/);
   const reaction = new reactions.ReactionDirectMessage();
 
-  rules.add(new models.Rule(expression, reaction));
+  defRules.add(new rules.Rule(expression, reaction));
 
-  return rules;
+  return defRules;
 }

--- a/test/message_handler_test.js
+++ b/test/message_handler_test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const should = require('should');
-const models = require('../src/models.js');
+const messages = require('../src/messages.js');
 const handler = require('../src/message_handler.js');
 
 describe("Message handler", function(){
@@ -15,7 +15,7 @@ describe("Message handler", function(){
 
     const user_message = handler.MessageHandler.getUserMessage(slack_data);
 
-    const expected_user_message = new models.UserMessage(slack_data.user, slack_data.text);
+    const expected_user_message = new messages.UserMessage(slack_data.user, slack_data.text);
 
     user_message.equals(expected_user_message).should.be.true();
   });
@@ -33,6 +33,6 @@ describe("Message handler", function(){
 
     const user_message = handler.MessageHandler.getUserMessage(slack_data);
 
-    user_message.should.be.instanceOf(models.NoMessage);
+    user_message.should.be.instanceOf(messages.NoMessage);
   });
 });

--- a/test/rules_parser_test.js
+++ b/test/rules_parser_test.js
@@ -1,0 +1,88 @@
+const assert = require('assert');
+const should = require('should');
+const rules = require('../src/rules.js');
+
+describe('Rules', () => {
+
+  it('Should properly parse rules', () => {
+
+    const rulesJson = {
+    	"rules": [{
+    		"term": "crazy",
+    		"reaction": "Please dont say crazy"
+    	}, {
+    		"term": "mad",
+    		"reaction": "Please dont say mad"
+    	}]
+    };
+
+    const parsedRules = rules.rulesFromJson(rulesJson);
+
+    assert(parsedRules.length().should.be.exactly(2));
+    assert(parsedRules.rules[0].expression.test('crazy').should.be.true());
+    assert(parsedRules.rules[0].reaction.message.should.be.exactly('Please dont say crazy'));
+    assert(parsedRules.rules[1].expression.test('mad').should.be.true());
+    assert(parsedRules.rules[1].reaction.message.should.be.exactly('Please dont say mad'));
+  });
+
+  it('Should ignore rules without a term', () => {
+    const rulesJson = {
+    	"rules": [{
+    		"reaction": "Please dont say crazy"
+    	}, {
+    		"term": "mad",
+    		"reaction": "Please dont say mad"
+    	}]
+    };
+
+    const parsedRules = rules.rulesFromJson(rulesJson);
+    assert(parsedRules.length().should.be.exactly(1));
+  });
+
+  it('Should ignore rules without a reaction', () => {
+    const rulesJson = {
+    	"rules": [{
+    		"term": "crazy",
+    	}, {
+    		"term": "mad",
+    		"reaction": "Please dont say mad"
+    	}]
+    };
+
+    const parsedRules = rules.rulesFromJson(rulesJson);
+    assert(parsedRules.length().should.be.exactly(1));
+  });
+
+  it('Should throw if no rules provided', () => {
+
+    // No JSON
+    assert.throws(() => {
+      rules.rulesFromJson();
+    },
+    checkError);
+
+    // Empty JSON
+    assert.throws(() => {
+      rules.rulesFromJson({});
+    },
+    checkError);
+
+    // JSON with empty rules
+    assert.throws(() => {
+      rules.rulesFromJson({rules: []});
+    },
+    checkError);
+
+    // JSON with only invalid rules
+    assert.throws(() => {
+      rules.rulesFromJson({rules: [{term: 'LOL'}, {reaction: 'LOL'}]});
+    },
+    checkError);
+  });
+});
+
+function checkError(error) {
+  if (error instanceof Error && /No rules found/.test(error)) {
+    return true;
+  }
+}


### PR DESCRIPTION
Thought for a second of leaving `config.json` out of GIT control, but then I realised that is important to provide an initial list. Also useful so it's easy for people to send PRs and contribute.

It's called `config.json` and not `rules.json` because in my head that's going to have more defaults in the future.

But we can change it later when the time comes.

Closes #3.