### PR TITLE
Analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "ustwo Fampany",
   "license": "MIT",
   "scripts": {
-    "test": "npm run unit && npm run lint",
+    "test": "npm run -s unit && npm run -s lint",
     "unit": "./node_modules/mocha/bin/mocha test/",
     "lint": "./node_modules/eslint/bin/eslint.js src/ --no-ignore .eslintrc.js"
   },

--- a/src/firebase_analytics.js
+++ b/src/firebase_analytics.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const firebase = require('firebase-admin');
+
+function trackEvent(db, path, value) {
+  db.ref(path).push(value, (error) => {
+    if (error) {
+      console.error(`Unable to track ${path}. Firebase error: ${error}`);
+    }
+  });
+}
+
+// Server side time stamp, more here:
+// https://firebase.google.com/docs/reference/android/com/google/firebase/database/ServerValue.html#TIMESTAMP
+function t() {
+  return firebase.database.ServerValue.TIMESTAMP;
+}
+
+class FirebaseAnalytics {
+  constructor(db) {
+    this.db = db;
+  }
+
+  trackCommand(command) {
+    trackEvent(this.db, '/analytics/commands', { command, timestamp: t() });
+  }
+
+  trackUsers(total, interested) {
+    trackEvent(this.db, '/analytics/users', { total, interested, timestamp: t() });
+  }
+
+  trackTerm(term, isInterested) {
+    trackEvent(this.db, '/analytics/terms', { term, isInterested, timestamp: t() });
+  }
+}
+
+module.exports = {
+  FirebaseAnalytics,
+};

--- a/src/firebase_analytics.js
+++ b/src/firebase_analytics.js
@@ -2,6 +2,10 @@
 
 const firebase = require('firebase-admin');
 
+// Server side time stamp, more here:
+// https://firebase.google.com/docs/reference/android/com/google/firebase/database/ServerValue.html#TIMESTAMP
+const timestamp = firebase.database.ServerValue.TIMESTAMP;
+
 function trackEvent(db, path, value) {
   db.ref(path).push(value, (error) => {
     if (error) {
@@ -10,27 +14,21 @@ function trackEvent(db, path, value) {
   });
 }
 
-// Server side time stamp, more here:
-// https://firebase.google.com/docs/reference/android/com/google/firebase/database/ServerValue.html#TIMESTAMP
-function t() {
-  return firebase.database.ServerValue.TIMESTAMP;
-}
-
 class FirebaseAnalytics {
   constructor(db) {
     this.db = db;
   }
 
   trackCommand(command) {
-    trackEvent(this.db, '/analytics/commands', { command, timestamp: t() });
+    trackEvent(this.db, '/analytics/commands', { command, timestamp });
   }
 
   trackUsers(total, interested) {
-    trackEvent(this.db, '/analytics/users', { total, interested, timestamp: t() });
+    trackEvent(this.db, '/analytics/users', { total, interested, timestamp });
   }
 
   trackTerm(term, isInterested) {
-    trackEvent(this.db, '/analytics/terms', { term, isInterested, timestamp: t() });
+    trackEvent(this.db, '/analytics/terms', { term, isInterested, timestamp });
   }
 }
 

--- a/src/firebase_datastore.js
+++ b/src/firebase_datastore.js
@@ -38,7 +38,10 @@ class FirebaseDataStore {
   getInterestedUsers(successCallback, errorCallback) {
     this.db.ref('users').orderByChild('interested').equalTo(true).once('value', (data) => {
       if (successCallback) {
-        const totalRegisteredUsers = Object.keys(data.val()).length;
+        let totalRegisteredUsers = 0;
+        if (data.val() != null) {
+          totalRegisteredUsers = Object.keys(data.val()).length;
+        }
         successCallback(totalRegisteredUsers);
       }
     }, (errorObject) => {

--- a/src/firebase_datastore.js
+++ b/src/firebase_datastore.js
@@ -34,6 +34,20 @@ class FirebaseDataStore {
       }
     });
   }
+
+  getInterestedUsers(successCallback, errorCallback) {
+    this.db.ref('users').orderByChild('interested').equalTo(true).once('value', (data) => {
+      if (successCallback) {
+        const totalRegisteredUsers = Object.keys(data.val()).length;
+        successCallback(totalRegisteredUsers);
+      }
+    }, (errorObject) => {
+      console.log(`Firebase DataStore error: ${errorObject}`);
+      if (errorCallback) {
+        errorCallback(errorObject.code);
+      }
+    });
+  }
 }
 
 module.exports = {

--- a/src/language_checker.js
+++ b/src/language_checker.js
@@ -16,6 +16,7 @@ class LanguageChecker {
 
       if (rule.expression.test(message.text)) {
         reaction = rule.reaction;
+        reaction.expression = rule.expression.toString();
         break;
       }
     }

--- a/src/reactions.js
+++ b/src/reactions.js
@@ -6,6 +6,7 @@ class ReactionNone {
 class ReactionDirectMessage {
   constructor(message) {
     this.message = message;
+    this.expression = null;
   }
 
   // YES, this needs the user_name, sadly not the ID as per:

--- a/src/slack_gateway.js
+++ b/src/slack_gateway.js
@@ -8,9 +8,7 @@ class SlackGateway {
   getTotalUsers(successCallback, errorCallback) {
     this.slackBot.getUsers().then((usersData) => {
       successCallback(usersData.members.length);
-    }, (error) => {
-      errorCallback(error);
-    });
+    }, errorCallback);
   }
 }
 

--- a/src/slack_gateway.js
+++ b/src/slack_gateway.js
@@ -1,0 +1,19 @@
+'use strict';
+
+class SlackGateway {
+  constructor(slackBot) {
+    this.slackBot = slackBot;
+  }
+
+  getTotalUsers(successCallback, errorCallback) {
+    this.slackBot.getUsers().then((usersData) => {
+      successCallback(usersData.members.length);
+    }, (error) => {
+      errorCallback(error);
+    });
+  }
+}
+
+module.exports = {
+  SlackGateway,
+};

--- a/src/wordy_bot.js
+++ b/src/wordy_bot.js
@@ -6,7 +6,7 @@ const messages = require('./messages.js');
 const reactions = require('./reactions.js');
 
 class WordyBot {
-  constructor(dataStore, slackBot, rules) {
+  constructor(dataStore, analytics, slackBot, rules) {
     // TODO: extract the anonymous callbacks from each slackBot.on call
     // so they can be tested outside the event cycle
     slackBot.on('start', () => {
@@ -37,6 +37,7 @@ class WordyBot {
           dataStore.isUserInterested(userMessage.userId, (isInterested) => {
             if (isInterested) {
               console.log('User is interested');
+              analytics.trackTerm(reaction.expression, true);
 
               // TODO: this is ugly because apparently the only way to send a DM
               // is via the user name, which doesn't come from the slack_data object received.
@@ -56,10 +57,11 @@ class WordyBot {
                 }
               });
             } else {
-              console.log(`${userMessage.userId} IS ***NOT**** INTERESTED`);
+              console.info('User is ***NOT**** interested');
+              analytics.trackTerm(reaction.expression, false);
             }
           }, (error) => {
-            console.log(`DATA STORE ERROR: ${error}`);
+            console.error(`DATA STORE ERROR: ${error}`);
           }); // is user interested callback
         } // reaction is direct message
       }

--- a/src/wordy_webserver_analytics.js
+++ b/src/wordy_webserver_analytics.js
@@ -1,0 +1,17 @@
+'use strict';
+
+function trackCommand(analytics) {
+  return (req, res, next) => {
+    const command = req.body.command;
+    if (command) {
+      analytics.trackCommand(command);
+    } else {
+      console.error('Command not found in request, cannot track.');
+    }
+    next();
+  };
+}
+
+module.exports = {
+  trackCommand,
+};

--- a/src/wordy_webserver_response.js
+++ b/src/wordy_webserver_response.js
@@ -2,44 +2,85 @@
 
 const moment = require('moment');
 
-// Private, not exported
-function userIn(storage, userId, callback) {
-  storage.registerUser(userId, true, () => {
-    console.log(`User ${userId} successfully registered`);
-    callback('Thank you for registering.');
-  }, (error) => {
-    console.error(`Error trying to register user ${userId}, error: ${error}`);
-    callback(`Ooops, something went wrong: ${error}`);
-  });
+function reportError(error, responseCallback) {
+  responseCallback(`Ooops, something went wrong: ${error}`);
 }
 
-function userOut(storage, userId, callback) {
-  storage.registerUser(userId, false, () => {
-    console.log(`User ${userId} successfully unregistered`);
-    callback('Sorry to see you go.');
-  }, (error) => {
-    console.error(`Error trying to unregister user ${userId}, error: ${error}`);
-    callback(`Ooops, something went wrong: ${error}`);
-  });
+function getInterestedUsersSuccess(analytics, totalUsers, responseCallback, message) {
+  return (totalRegisteredUsers) => {
+    console.log(`Found ${totalRegisteredUsers} interested users`);
+    analytics.trackUsers(totalUsers, totalRegisteredUsers);
+    responseCallback(message);
+  };
+}
+
+function getInterestedUsersError(responseCallback) {
+  return (error) => {
+    console.error(`Error trying to get total interested users, error: ${error}`);
+    reportError(error, responseCallback);
+  };
+}
+
+function getTotalUsersSuccess(analytics, storage, responseCallback, message) {
+  return (totalUsers) => {
+    console.log(`Found ${totalUsers} users in Slack`);
+    storage.getInterestedUsers(getInterestedUsersSuccess(analytics,
+                                                          totalUsers,
+                                                          responseCallback,
+                                                          message),
+                              getInterestedUsersError(responseCallback));
+  };
+}
+
+function getTotalUsersError(responseCallback) {
+  return (error) => {
+    console.error(`Error trying to get total Slack users: ${error}`);
+    reportError(error, responseCallback);
+  };
+}
+
+function successRegister(gateway, analytics, storage, responseCallback, message) {
+  return () => {
+    console.log('User successfully updated');
+    gateway.getTotalUsers(getTotalUsersSuccess(analytics, storage, responseCallback, message),
+                          getTotalUsersError(responseCallback));
+  };
+}
+
+function failedRegister(responseCallback) {
+  return (error) => {
+    console.error(`Error trying to update user, error: ${error}`);
+    reportError(error, responseCallback);
+  };
+}
+
+function userIn(gateway, analytics, storage, userId, callback) {
+  storage.registerUser(userId, true,
+                        successRegister(gateway, analytics, storage, callback, 'Thank you for registering.'),
+                        failedRegister(callback));
+}
+
+function userOut(gateway, analytics, storage, userId, callback) {
+  storage.registerUser(userId, false,
+                        successRegister(gateway, analytics, storage, callback, 'Sorry to see you go.'),
+                        failedRegister(callback));
 }
 
 function ping(callback) {
   callback(`Pong! Alive since ${moment.duration(process.uptime() * 1000).humanize()}`);
 }
 
-function processCommand(storage, req, callback) {
+function processCommand(gateway, analytics, storage, req, callback) {
   const command = req.body.command;
   const userId = req.body.user_id;
 
-  console.log('Command received');
   console.log(`Command: ${command}`);
-  console.log(`User ID: ${userId}`);
 
   // We are wrapping the actual callbacks so they can have
   // different method signatures.
   const commandMap = {
-    '/wordy-in': () => userIn(storage, userId, callback),
-    '/wordy-out': () => userOut(storage, userId, callback),
+    '/wordy-in': () => userIn(gateway, analytics, storage, userId, callback),
+    '/wordy-out': () => userOut(gateway, analytics, storage, userId, callback),
     '/wordy-ping': () => ping(callback),
   };
 

--- a/test/dummy_analytics.js
+++ b/test/dummy_analytics.js
@@ -1,0 +1,19 @@
+'use strict';
+
+class DummyAnalytics {
+  constructor() {
+  }
+
+  trackCommand(command) {
+  }
+
+  trackUsers(total, interested) {
+  }
+
+  trackTerm(term, isInterested) {
+  }
+}
+
+module.exports = {
+  DummyAnalytics,
+};

--- a/test/dummy_datastore.js
+++ b/test/dummy_datastore.js
@@ -11,6 +11,10 @@ class DummyDataStore {
   registerUser(userId, isInterested, successCallback, errorCallback) {
     successCallback();
   }
+
+  getInterestedUsers(successCallback, errorCallback) {
+    successCallback(5);
+  }
 }
 
 module.exports = {

--- a/test/dummy_slack_gateway.js
+++ b/test/dummy_slack_gateway.js
@@ -1,0 +1,14 @@
+'use strict';
+
+class DummySlackGateway {
+  constructor() {
+  }
+
+  getTotalUsers(successCallback, errorCallback) {
+    successCallback(5);
+  }
+}
+
+module.exports = {
+  DummySlackGateway,
+};

--- a/test/firebase_analytics_test.js
+++ b/test/firebase_analytics_test.js
@@ -1,0 +1,50 @@
+const assert = require('assert');
+const should = require('should');
+const sinon = require('sinon');
+const firebase = require('firebase-admin');
+const analytics = require('../src/firebase_analytics.js');
+
+describe('Firebase Analytics', () => {
+
+  var sandbox, mockDb, mockPush, mockRef, fbAnalytics;
+
+  beforeEach(function(){
+    sandbox = sinon.sandbox.create();
+
+    mockDb = {ref: function(){}};
+    mockPush = sandbox.spy();
+    mockRef = sandbox.stub(mockDb, 'ref').returns({push: mockPush});
+
+    fbAnalytics = new analytics.FirebaseAnalytics(mockDb);
+  });
+
+  afterEach(function(){
+    sandbox.restore();
+  });
+
+  it('Should track commands', () => {
+    const command = '/wadus';
+    fbAnalytics.trackCommand(command);
+
+    assert(mockRef.calledWith('/analytics/commands'));
+    assert(mockPush.calledWith({command: command, timestamp: firebase.database.ServerValue.TIMESTAMP}));
+  });
+
+  it('Should track terms', () => {
+    const term = 'guys';
+    const isInterested = true;
+    fbAnalytics.trackTerm(term, isInterested);
+
+    assert(mockRef.calledWith('/analytics/terms'));
+    assert(mockPush.calledWith({term: term, isInterested: isInterested, timestamp: firebase.database.ServerValue.TIMESTAMP}));
+  });
+
+  it('Should track users', () => {
+    const total = 56;
+    const interested = 34;
+    fbAnalytics.trackUsers(total, interested);
+
+    assert(mockRef.calledWith('/analytics/users'));
+    assert(mockPush.calledWith({total: total, interested: interested, timestamp: firebase.database.ServerValue.TIMESTAMP}));
+  });
+});

--- a/test/firebase_datastore_test.js
+++ b/test/firebase_datastore_test.js
@@ -117,6 +117,13 @@ describe('Firebase Data Store', function(){
     assert(mockSuccessCallback.calledWithExactly(2));
   });
 
+  it('Should return 0 as the number of users registered if the table is empty', () => {
+    ds.getInterestedUsers(mockSuccessCallback, mockErrorCallback);
+
+    mockOnce.args[0][1]({val: () => {return null;}});
+    assert(mockSuccessCallback.calledWithExactly(0));
+  });
+
   it('Should call the error callback if cant retrive number of registered users', () => {
     ds.getInterestedUsers(mockSuccessCallback, mockErrorCallback);
 

--- a/test/firebase_datastore_test.js
+++ b/test/firebase_datastore_test.js
@@ -5,20 +5,23 @@ const dataStore = require('../src/firebase_datastore.js');
 
 describe('Firebase Data Store', function(){
 
-  var sandbox, mock_db, mock_once, mock_ref, mock_success_callback, ds;
+  var sandbox, mockDb, mockOnce, mockRef, mockOrderByChild, mockSuccessCallback, ds;
+  var mockUpdate, mockErrorCallback;
 
   beforeEach(function(){
     sandbox = sinon.sandbox.create();
 
     // Bit too much set up :|
-    mock_db = {ref: function(){}};
-    mock_once = sandbox.spy();
-    mock_update = sandbox.spy();
-    mock_ref = sandbox.stub(mock_db, 'ref').returns({once: mock_once, update: mock_update});
-    mock_success_callback = sandbox.spy();
-    mock_error_callback = sandbox.spy();
+    mockDb = {ref: function(){}};
+    mockOnce = sandbox.spy();
+    mockUpdate = sandbox.spy();
+    mockEqualTo = sandbox.stub().returns({once: mockOnce});
+    mockOrderByChild = sandbox.stub().returns({equalTo: mockEqualTo});
+    mockRef = sandbox.stub(mockDb, 'ref').returns({once: mockOnce, update: mockUpdate, orderByChild: mockOrderByChild});
+    mockSuccessCallback = sandbox.spy();
+    mockErrorCallback = sandbox.spy();
 
-    ds = new dataStore.FirebaseDataStore(mock_db);
+    ds = new dataStore.FirebaseDataStore(mockDb);
   });
 
   afterEach(function(){
@@ -28,79 +31,99 @@ describe('Firebase Data Store', function(){
   it('Should call Firebase JS SDK appropiately', function(){
     ds.isUserInterested('USER_ID');
 
-    assert(mock_ref.calledWith('users/USER_ID'));
-    assert(mock_once.calledWith('value'));
+    assert(mockRef.calledWith('users/USER_ID'));
+    assert(mockOnce.calledWith('value'));
   });
 
   it('Should return false if the user has not registered', function(){
-    ds.isUserInterested('USER_ID', mock_success_callback);
+    ds.isUserInterested('USER_ID', mockSuccessCallback);
 
     // Firebase returns null for data.val() if
     // no record can be found
-    mock_once.args[0][1]({val: function(){ return null;}});
+    mockOnce.args[0][1]({val: function(){ return null;}});
 
-    assert(mock_success_callback.calledWith(false));
+    assert(mockSuccessCallback.calledWith(false));
   });
 
   it('Should return false if the user has opted out', function() {
-    ds.isUserInterested('USER_ID', mock_success_callback);
+    ds.isUserInterested('USER_ID', mockSuccessCallback);
 
-    mock_once.args[0][1](getMockDbData(false));
+    mockOnce.args[0][1](getMockDbData(false));
 
-    assert(mock_success_callback.calledWith(false));
+    assert(mockSuccessCallback.calledWith(false));
   });
 
   it('Should return true if the user has opted in', function(){
-    ds.isUserInterested('USER_ID', mock_success_callback);
+    ds.isUserInterested('USER_ID', mockSuccessCallback);
 
     // This is executing the success callback
     // passing our mocked db data
-    mock_once.args[0][1](getMockDbData(true));
+    mockOnce.args[0][1](getMockDbData(true));
 
-    assert(mock_success_callback.calledWith(true));
+    assert(mockSuccessCallback.calledWith(true));
   });
 
   it('Should call error callback appropiately when there is a Firebase error', function(){
-    ds.isUserInterested('USER_ID', mock_success_callback, mock_error_callback);
+    ds.isUserInterested('USER_ID', mockSuccessCallback, mockErrorCallback);
 
     const errorObject = {code: 'XXXXX'};
 
     // This is executing the error callback
     // passing the mock error object
-    mock_once.args[0][2](errorObject);
+    mockOnce.args[0][2](errorObject);
 
-    assert(mock_error_callback.calledWith(errorObject.code));
+    assert(mockErrorCallback.calledWith(errorObject.code));
   });
 
   it('Should appropriately opt in a user', function(){
     ds.registerUser('USER_ID', true);
 
-    assert(mock_ref.calledWith('users/USER_ID'));
-    assert(mock_update.calledWith({interested: true}));
+    assert(mockRef.calledWith('users/USER_ID'));
+    assert(mockUpdate.calledWith({interested: true}));
   });
 
   it('Should appropriately opt out a user', function(){
     ds.registerUser('USER_ID', false);
 
-    assert(mock_ref.calledWith('users/USER_ID'));
-    assert(mock_update.calledWith({interested: false}));
+    assert(mockRef.calledWith('users/USER_ID'));
+    assert(mockUpdate.calledWith({interested: false}));
   });
 
   it('Should call the success callback after successful update', function(){
-    ds.registerUser('USER_ID', false, mock_success_callback);
+    ds.registerUser('USER_ID', false, mockSuccessCallback);
 
-    mock_update.args[0][1]();
+    mockUpdate.args[0][1]();
 
-    assert(mock_success_callback.calledWithExactly());
+    assert(mockSuccessCallback.calledWithExactly());
   });
 
   it('Should call the error callback after unsuccessful update', function(){
-    ds.registerUser('USER_ID', false, mock_success_callback, mock_error_callback);
+    ds.registerUser('USER_ID', false, mockSuccessCallback, mockErrorCallback);
 
-    const db_error = 'XXXXX';
-    mock_update.args[0][1](db_error);
+    const dbError = 'XXXXX';
+    mockUpdate.args[0][1](dbError);
 
-    assert(mock_error_callback.calledWithExactly(db_error));
+    assert(mockErrorCallback.calledWithExactly(dbError));
+  });
+
+  it('Should return the number of registered users', () => {
+    ds.getInterestedUsers(mockSuccessCallback, mockErrorCallback);
+
+    mockOnce.args[0][1]({val: () => {return {lol: {interested: true}, wadus: {interested: true}}}});
+
+    assert(mockRef.calledWith('users'));
+    assert(mockOrderByChild.calledWith('interested'));
+    assert(mockEqualTo.calledWith(true));
+    assert(mockSuccessCallback.calledWithExactly(2));
+  });
+
+  it('Should call the error callback if cant retrive number of registered users', () => {
+    ds.getInterestedUsers(mockSuccessCallback, mockErrorCallback);
+
+    const errorObject = {code: 'XXXXX'};
+    mockOnce.args[0][2](errorObject);
+
+    assert(mockErrorCallback.calledWithExactly(errorObject.code));
   });
 });
 

--- a/test/slack_gateway_test.js
+++ b/test/slack_gateway_test.js
@@ -1,0 +1,40 @@
+const assert = require('assert');
+const should = require('should');
+const sinon = require('sinon');
+const slackGateway = require('../src/slack_gateway.js');
+
+describe('Slack Gateway', () => {
+
+  var sandbox, mockSlackBot, mockSuccessCallback, mockErrorCallback, gateway;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    mockThen = sandbox.spy();
+    mockSuccessCallback = sandbox.spy();
+    mockErrorCallback = sandbox.spy();
+    mockSlackBot = {getUsers: () => {return {then: mockThen}}};
+    gateway = new slackGateway.SlackGateway(mockSlackBot);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('Should return number of users', () => {
+    gateway.getTotalUsers(mockSuccessCallback, mockErrorCallback);
+
+    const mockUsersData = [{}, {}];
+    mockThen.args[0][0]({members: mockUsersData});
+    assert(mockSuccessCallback.calledWith(mockUsersData.length));
+    assert(mockErrorCallback.callCount.should.be.exactly(0));
+  });
+
+  it('Should execute the error callback if something does not work', () => {
+    gateway.getTotalUsers(mockSuccessCallback, mockErrorCallback);
+
+    const error = 'SOME ERROR';
+    mockThen.args[0][1](error);
+    assert(mockSuccessCallback.callCount.should.be.exactly(0));
+    assert(mockErrorCallback.calledWith(error));
+  });
+});

--- a/test/wordy_bot_test.js
+++ b/test/wordy_bot_test.js
@@ -12,7 +12,7 @@ describe('WordyBot', function(){
 
     sinon.spy(slackBot, 'on');
 
-    const bot = new bots.WordyBot(null, slackBot, null);
+    const bot = new bots.WordyBot(null, null, slackBot, null);
 
     assert(slackBot.on.calledWith('message'));
 

--- a/test/wordy_webserver_analytics_test.js
+++ b/test/wordy_webserver_analytics_test.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+const should = require('should');
+const sinon = require('sinon');
+const serverAnalytics = require('../src/wordy_webserver_analytics.js');
+
+describe('Wordy WebServer Analytics', () => {
+
+  var mockRequest, mockResponse, mockNextCallback, mockAnalytics;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    mockRequest = {body: {command: 'wadus'}};
+    mockResponse = sandbox.spy();
+    mockNextCallback = sandbox.spy();
+    mockAnalyticsTrackCommand = sandbox.spy();
+    mockAnalytics = {trackCommand: mockAnalyticsTrackCommand};
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('Should properly track the command', () => {
+    const mid = serverAnalytics.trackCommand(mockAnalytics);
+    mid(mockRequest, mockResponse, mockNextCallback);
+
+    assert(mockAnalyticsTrackCommand.calledWith(mockRequest.body.command));
+    assert(mockNextCallback.called);
+  });
+
+  it('Should call next middleware function even if no command found', () => {
+    mockRequest = {body : {}};
+    const mid = serverAnalytics.trackCommand(mockAnalytics);
+    mid(mockRequest, mockResponse, mockNextCallback);
+
+    assert(mockAnalyticsTrackCommand.callCount.should.be.exactly(0));
+    assert(mockNextCallback.called);
+  });
+});

--- a/test/wordy_webserver_test.js
+++ b/test/wordy_webserver_test.js
@@ -3,6 +3,8 @@ const should = require('should');
 const request = require('supertest');
 const server = require('../src/wordy_webserver.js');
 const storage = require('../test/dummy_datastore.js');
+const analytics = require('../test/dummy_analytics.js');
+const slackGateway = require('../test/dummy_slack_gateway.js');
 
 // This is outside testing (booting up the server, making actual HTTP calls)
 // particularly around authentication
@@ -21,7 +23,11 @@ describe('Wordy WebServer', () => {
   const SLACK_TEAM_ID = 'SOME_SLACK_TEAM_ID';
 
   beforeEach(() => {
-    webServer = new server.WordyWebServer(new storage.DummyDataStore(), PORT, HOST, SLACK_COMMAND_TOKEN, SLACK_TEAM_ID);
+    webServer = new server.WordyWebServer(new slackGateway.DummySlackGateway(),
+                                          new storage.DummyDataStore(),
+                                          new analytics.DummyAnalytics(),
+                                          PORT, HOST,
+                                          SLACK_COMMAND_TOKEN, SLACK_TEAM_ID);
   });
 
   afterEach((done) => {


### PR DESCRIPTION
Fairly chunky update to get analytics in place. Ended up tracking:

 * Commands, known and unknown.
 * All monitored terms and whether the user was opted-in or not at the time. NOTE: what we track is not the message itself, but the matching RegExp as defined in `config.json`. I found this less intuitive at first, but then realised that it would make reporting easier in the long run.
 * How many users are in total and how many of those are interested. These events are tracked whenever someone opts in or out so we can plot that data over time. 

This closes #16.